### PR TITLE
Temp fix to the wrong date being passed through into getOneDateEnergyBySn()

### DIFF
--- a/alphaess/alphaess.py
+++ b/alphaess/alphaess.py
@@ -90,8 +90,11 @@ class alphaess:
     
     async def getOneDateEnergyBySn(self,sysSn,queryDate) -> Optional(list):
         """According SN to get System Energy Data"""
-        resource = f"{BASEURL}/getOneDateEnergyBySn?sysSn={sysSn}&queryDate={queryDate}"
+        logger.debug(f"DATE: {queryDate}")
+        localdate = time.strftime("%Y-%m-%d")
+        logger.debug(f"DATE: {localdate}")
 
+        resource = f"{BASEURL}/getOneDateEnergyBySn?sysSn={sysSn}&queryDate={localdate}"
         logger.debug(f"Trying to get one day energy information for system {sysSn}")
 
         data = await self.__get_data(resource)
@@ -240,7 +243,7 @@ class alphaess:
                 if "sysSn" in unit:
                     serial = unit["sysSn"]
                     unit ['SumData'] = await self.getSumDataForCustomer(serial)
-                    unit['OneDateEnergy'] = await self.getOneDateEnergyBySn(serial,time.strftime("%Y-%m-%d"))
+                    unit['OneDateEnergy'] = await self.getOneDateEnergyBySn(serial, time.strftime("%Y-%m-%d"))
                     unit['LastPower'] = await self.getLastPowerData(serial)
                     unit['ChargeConfig'] = await self.getChargeConfigInfo(serial)
                     unit['DisChargeConfig'] = await self.getDisChargeConfigInfo(serial)


### PR DESCRIPTION
No idea why this is the case; by adjusting the `time.strftime` to be ran within the function, rather than parsed into it. i got 2 different dates, with the latter being correct.

As seen here
```
[Mon, 27 Nov 2023 00:41:46] DEBUG [alphaess.py.getOneDateEnergyBySn:93] DATE: 2023-11-26
[Mon, 27 Nov 2023 00:41:46] DEBUG [alphaess.py.getOneDateEnergyBySn:95] DATE: 2023-11-27
```

I got no idea why this is the case, but its a fix for now and should report the local date to the API call


