### PR TITLE
Guard against getESSList() returning None ('NoneType' object is not iterable)

### DIFF
--- a/alphaess/alphaess.py
+++ b/alphaess/alphaess.py
@@ -419,6 +419,12 @@ class alphaess:
                     }
 
             units = await self.getESSList()
+            if units is None:
+                logger.warning(
+                    "getESSList returned no data (Alpha ESS API busy or unavailable); "
+                    "skipping this update cycle"
+                )
+                return alldata
             for idx, unit in enumerate(units):
                 if "sysSn" in unit:
                     serial = unit["sysSn"]
@@ -471,6 +477,12 @@ class alphaess:
         try:
             success = False
             units = await self.getESSList()
+            if units is None:
+                logger.error(
+                    "Authentication check failed: getESSList returned no data "
+                    "(Alpha ESS API busy or unavailable)"
+                )
+                return False
             for unit in units:
                 if "sysSn" in unit:
                     success = True

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="alphaessopenapi",
-    version="0.0.18",
+    version="0.0.19",
     author="Charles Gillanders",
     author_email="charles@charlesgillanders.com",
     description="A python library to retrieve energy statistics from your Alpha ESS inverter by polling the Official Alpha ESS Open API.",


### PR DESCRIPTION
## Problem

`getESSList()` is declared `-> Optional[list]` and legitimately returns `None` whenever the underlying `api_get()` receives a non-success / empty payload **or** the Alpha ESS cloud is briefly unreachable (connection timeout, `Cannot connect to host openapi.alphaess.com`).

But `getdata()` and `authenticate()` iterate the result without a `None` check:

```python
units = await self.getESSList()
for idx, unit in enumerate(units):   # 'NoneType' object is not iterable when units is None
```

So any time `getESSList()` returns `None`, the entire poll raises `'NoneType' object is not iterable` (logged under the `alphaess.alphaess` logger and re-raised). Observed in the wild on a transient cloud hiccup:

```
ERROR [alphaess.alphaess] Connection timeout to host https://openapi.alphaess.com/api/getEssList
ERROR [alphaess.alphaess] Error: Connection timeout to host https://openapi.alphaess.com/api/getEssList when calling ...
ERROR [alphaess.alphaess] 'NoneType' object is not iterable
WARNING [custom_components.alphaess] Cloud API error: 'NoneType' object is not iterable
```

(The Home Assistant integration catches it downstream and falls back, but the library shouldn't throw on a return value its own type hint declares possible.)

## Fix

Guard both iteration sites against `None`:
- `getdata()` logs a warning and returns the (empty) `alldata` list, so the caller keeps its previous data instead of crashing.
- `authenticate()` returns `False`.

No behavioural change when the API responds normally.
