### PR TITLE
Fix: re-raise exceptions instead of silently swallowing them

### DIFF
--- a/alphaess/alphaess.py
+++ b/alphaess/alphaess.py
@@ -66,6 +66,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getLastPowerData(self, sysSn) -> Optional(list):
         """According SN to get real-time power data"""
@@ -78,6 +79,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getOneDayPowerBySn(self, sysSn, queryDate=None) -> Optional(list):
         """According SN to get system power data"""
@@ -92,6 +94,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getSumDataForCustomer(self, sysSn) -> Optional(list):
         """According SN to get System Summary data"""
@@ -104,6 +107,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getOneDateEnergyBySn(self, sysSn, queryDate=None) -> Optional(list):
         """According SN to get System Energy Data"""
@@ -118,6 +122,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getChargeConfigInfo(self, sysSn) -> Optional(list):
         """According SN to get charging setting information"""
@@ -130,6 +135,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getDisChargeConfigInfo(self, sysSn) -> Optional(list):
         """According to SN discharge setting information"""
@@ -142,6 +148,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getEvChargerConfigList(self, sysSn) -> Optional(list):
         """According to SN get Ev Charger Config List"""
@@ -154,6 +161,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def setEvChargerCurrentsBySn(self, sysSn, currentsetting) -> Optional(list):
         """According to SN set Ev Charger Currents"""
@@ -171,6 +179,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getEvChargerCurrentsBySn(self, sysSn) -> Optional(list):
         """According to SN get Ev Charger Currents"""
@@ -183,6 +192,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getEvChargerStatusBySn(self, sysSn, evchargerSn) -> Optional(list):
         """According to SN get Ev Charger Status"""
@@ -195,6 +205,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def remoteControlEvCharger(self, sysSn, evchargerSn, controlMode) -> Optional(dict):
         """According SN to Remote Control Ev Charger"""
@@ -213,6 +224,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def bindSn(self, sysSn, code) -> Optional(dict):
         """According to SN to Bind SN"""
@@ -230,6 +242,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getVerificationCode(self, sysSn, checkCode) -> Optional(dict):
         """According SN to Get Verification Code"""
@@ -247,6 +260,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def unBindSn(self, sysSn) -> Optional(dict):
         """According SN to UnBind SN"""
@@ -263,6 +277,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def updateChargeConfigInfo(self, sysSn, batHighCap, gridCharge, timeChae1, timeChae2, timeChaf1,
                                      timeChaf2) -> Optional(dict):
@@ -286,6 +301,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def updateDisChargeConfigInfo(self, sysSn, batUseCap, ctrDis, timeDise1, timeDise2, timeDisf1,
                                         timeDisf2) -> Optional(dict):
@@ -309,6 +325,7 @@ class alphaess:
 
         except Exception as e:
             logger.error(f"Error: {e} when calling {resource}")
+            raise
 
     async def getIPData(self) -> Optional(dict):
         ENDPOINTS = {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="alphaessopenapi",
-    version="0.0.19",
+    version="0.0.20",
     author="Charles Gillanders",
     author_email="charles@charlesgillanders.com",
     description="A python library to retrieve energy statistics from your Alpha ESS inverter by polling the Official Alpha ESS Open API.",


### PR DESCRIPTION
Fixes #26.

## Problem

17 wrapper methods (`getESSList`, `getSumDataForCustomer`, `getOneDateEnergyBySn`, `getLastPowerData`, `getChargeConfigInfo`, `getDisChargeConfigInfo`, `getEvChargerConfigList`, `setEvChargerCurrentsBySn`, `getEvChargerCurrentsBySn`, `getEvChargerStatusBySn`, `remoteControlEvCharger`, `bindSn`, `getVerificationCode`, `unBindSn`, `updateChargeConfigInfo`, `updateDisChargeConfigInfo`) catch exceptions from `api_get()`/`api_post()`, log them, and return `None` without re-raising — even though `api_get`/`api_post` themselves already correctly `raise` after logging. Full detail and reproduction in #26.

Net effect: any real failure (DNS blip, connection reset, etc.) reaching one of these methods comes back to the caller as `None`. `homeassistant-alphaESS`'s `coordinator.py` calls these methods directly and has `except (aiohttp.ClientConnectorError, ...)` specifically to let Home Assistant's `DataUpdateCoordinator` mark a failed update and retry with backoff — but that path can't be reached, because the exception never leaves this library. Observed effect on my own instance: entities stuck `unavailable` for 5+ hours after a 3-minute network outage, on a 60-second poll interval, until a manual config-entry reload.

## Fix

Add `raise` after the existing `logger.error(f"Error: {e} when calling {resource}")` in each of the 17 methods — one line each, no other behavioural change. This matches the pattern already used correctly elsewhere in the same file: `api_get`, `api_post`, `getdata`, `authenticate`, `setbatterycharge`, `setbatterydischarge` all already do `logger.error(...); raise`.

Also bumped `setup.py` to 0.0.20 following the convention from #25.

## Testing

I don't have `aiohttp`/`voluptuous` installable in my current environment (no pip/venv available) to run this live against a real or mocked API failure, so I can't attach a test run. What I did verify:
- `python3 -m py_compile alphaess/alphaess.py` passes
- Grepped for the exact swallow pattern (`logger.error(f"Error: {e} when calling {resource}")`) — confirmed exactly 17 occurrences, all now followed by `raise`
- Manually traced every one of the 17 methods to confirm the `try`/`except` structure and indentation are unchanged aside from the added line — this is a purely additive change (`raise` re-raising the currently-caught exception), so there's no new control-flow path introduced, only the existing one becoming reachable
- Confirmed `getdata()` and `authenticate()`'s existing `if units is None:` guards (from #25) are untouched and still meaningful — `api_get()` can still legitimately return `None` on a successful-but-empty API response (not just on exceptions), so those guards aren't made redundant by this change

Happy to add a proper mocked test if there's an existing test setup I should target — didn't see one in the repo.
